### PR TITLE
feat(contracts): [LN-047] CREATE2 + ERC-1167 deposit forwarder

### DIFF
--- a/script/DeployForwarder.s.sol
+++ b/script/DeployForwarder.s.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Script, console} from "forge-std/Script.sol";
+import {DepositForwarder} from "../src/DepositForwarder.sol";
+import {ForwarderFactory} from "../src/ForwarderFactory.sol";
+
+contract DeployForwarder is Script {
+    function run() external {
+        uint256 deployerKey = vm.envUint("PRIVATE_KEY");
+        address vault = vm.envAddress("VAULT_ADDRESS");
+
+        vm.startBroadcast(deployerKey);
+
+        DepositForwarder impl = new DepositForwarder();
+        ForwarderFactory factory = new ForwarderFactory(address(impl), vault);
+        impl.init(address(factory));
+
+        vm.stopBroadcast();
+
+        console.log("DepositForwarder implementation:", address(impl));
+        console.log("ForwarderFactory:", address(factory));
+    }
+}

--- a/src/DepositForwarder.sol
+++ b/src/DepositForwarder.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+error DepositForwarder_OnlyFactory();
+error DepositForwarder_AlreadyInitialized();
+error DepositForwarder_InvalidFactory();
+error DepositForwarder_LengthMismatch();
+error DepositForwarder_NativeTransferFailed();
+
+contract DepositForwarder {
+    using SafeERC20 for IERC20;
+
+    address private _factory;
+
+    event TokensFlushed(address indexed proxy, address indexed token, uint256 totalAmount);
+    event NativeFlushed(address indexed proxy, address indexed recipient, uint256 amount);
+
+    modifier onlyFactory() {
+        if (msg.sender != _factory) revert DepositForwarder_OnlyFactory();
+        _;
+    }
+
+    function init(address factory_) external {
+        if (_factory != address(0)) revert DepositForwarder_AlreadyInitialized();
+        if (factory_ == address(0)) revert DepositForwarder_InvalidFactory();
+        _factory = factory_;
+    }
+
+    function flushTokens(address token, address[] calldata recipients, uint256[] calldata amounts)
+        external
+        onlyFactory
+    {
+        if (recipients.length != amounts.length) revert DepositForwarder_LengthMismatch();
+        uint256 totalAmount;
+        IERC20 erc20 = IERC20(token);
+        for (uint256 i; i < recipients.length; ++i) {
+            erc20.safeTransfer(recipients[i], amounts[i]);
+            totalAmount += amounts[i];
+        }
+        emit TokensFlushed(address(this), token, totalAmount);
+    }
+
+    function flushNative(address payable recipient) external onlyFactory {
+        uint256 balance = address(this).balance;
+        (bool ok,) = recipient.call{value: balance}("");
+        if (!ok) revert DepositForwarder_NativeTransferFailed();
+        emit NativeFlushed(address(this), recipient, balance);
+    }
+
+    function factory() external view returns (address) {
+        return _factory;
+    }
+
+    receive() external payable {}
+}

--- a/src/ForwarderFactory.sol
+++ b/src/ForwarderFactory.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {DepositForwarder} from "./DepositForwarder.sol";
+
+error ForwarderFactory_InvalidAddress();
+
+contract ForwarderFactory is Ownable {
+    address public immutable implementation;
+    address public immutable vault;
+
+    event ProxyDeployed(address indexed proxy, bytes32 indexed salt);
+
+    constructor(address _implementation, address _vault) Ownable(msg.sender) {
+        if (_implementation == address(0)) revert ForwarderFactory_InvalidAddress();
+        if (_vault == address(0)) revert ForwarderFactory_InvalidAddress();
+        implementation = _implementation;
+        vault = _vault;
+    }
+
+    function computeAddress(bytes32 salt) external view returns (address) {
+        return Clones.predictDeterministicAddress(implementation, salt, address(this));
+    }
+
+    function deploy(bytes32 salt) public onlyOwner returns (address proxy) {
+        proxy = Clones.cloneDeterministic(implementation, salt);
+        DepositForwarder(payable(proxy)).init(address(this));
+        emit ProxyDeployed(proxy, salt);
+    }
+
+    function deployAndFlush(bytes32 salt, address token, address[] calldata recipients, uint256[] calldata amounts)
+        external
+        onlyOwner
+        returns (address proxy)
+    {
+        proxy = deploy(salt);
+        DepositForwarder(payable(proxy)).flushTokens(token, recipients, amounts);
+    }
+
+    function flushNative(address payable proxy, address payable recipient) external onlyOwner {
+        DepositForwarder(proxy).flushNative(recipient);
+    }
+
+    function batchFlushTokens(address[] calldata proxies, address token) external onlyOwner {
+        address[] memory recipients = new address[](1);
+        recipients[0] = vault;
+        uint256[] memory amounts = new uint256[](1);
+        for (uint256 i; i < proxies.length; ++i) {
+            uint256 balance = IERC20(token).balanceOf(proxies[i]);
+            if (balance == 0) continue;
+            amounts[0] = balance;
+            DepositForwarder(payable(proxies[i])).flushTokens(token, recipients, amounts);
+        }
+    }
+}

--- a/test/mocks/ERC20Mock.sol
+++ b/test/mocks/ERC20Mock.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract ERC20Mock is ERC20 {
+    uint8 private _decimals;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) ERC20(name_, symbol_) {
+        _decimals = decimals_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+}

--- a/test/unit/Forwarder.t.sol
+++ b/test/unit/Forwarder.t.sol
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+import {
+    DepositForwarder,
+    DepositForwarder_OnlyFactory,
+    DepositForwarder_AlreadyInitialized,
+    DepositForwarder_InvalidFactory
+} from "../../src/DepositForwarder.sol";
+import {ForwarderFactory, ForwarderFactory_InvalidAddress} from "../../src/ForwarderFactory.sol";
+import {ERC20Mock} from "../mocks/ERC20Mock.sol";
+
+contract ForwarderTest is Test {
+    DepositForwarder impl;
+    ForwarderFactory factory;
+    ERC20Mock token;
+
+    address vault = makeAddr("vault");
+    address buyer = makeAddr("buyer");
+    address owner;
+
+    function setUp() public {
+        owner = address(this);
+        impl = new DepositForwarder();
+        factory = new ForwarderFactory(address(impl), vault);
+        token = new ERC20Mock("MockUSDT", "USDT", 6);
+    }
+
+    function testComputeAddressIsDeterministic() public view {
+        bytes32 salt = keccak256("order-1");
+        address a = factory.computeAddress(salt);
+        address b = factory.computeAddress(salt);
+        assertEq(a, b);
+    }
+
+    function testComputeAddressMatchesDeployedProxy() public {
+        bytes32 salt = keccak256("order-2");
+        address predicted = factory.computeAddress(salt);
+        address deployed = factory.deploy(salt);
+        assertEq(predicted, deployed);
+    }
+
+    function testDeployAndFlush() public {
+        bytes32 salt = keccak256("order-3");
+        address predicted = factory.computeAddress(salt);
+
+        uint256 amount = 100e6;
+        token.mint(predicted, amount);
+
+        address[] memory recipients = new address[](1);
+        recipients[0] = buyer;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
+
+        factory.deployAndFlush(salt, address(token), recipients, amounts);
+        assertEq(token.balanceOf(buyer), amount);
+        assertEq(token.balanceOf(predicted), 0);
+    }
+
+    function testDeployAndFlushMultipleRecipients() public {
+        bytes32 salt = keccak256("order-4");
+        address predicted = factory.computeAddress(salt);
+
+        uint256 total = 100e6;
+        uint256 fee = 0.6e6;
+        uint256 net = total - fee;
+        token.mint(predicted, total);
+
+        address[] memory recipients = new address[](2);
+        recipients[0] = buyer;
+        recipients[1] = vault;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = net;
+        amounts[1] = fee;
+
+        factory.deployAndFlush(salt, address(token), recipients, amounts);
+        assertEq(token.balanceOf(buyer), net);
+        assertEq(token.balanceOf(vault), fee);
+    }
+
+    function testBatchFlushTokens() public {
+        bytes32 salt1 = keccak256("batch-1");
+        bytes32 salt2 = keccak256("batch-2");
+
+        address proxy1 = factory.deploy(salt1);
+        address proxy2 = factory.deploy(salt2);
+
+        token.mint(proxy1, 50e6);
+        token.mint(proxy2, 75e6);
+
+        address[] memory proxies = new address[](2);
+        proxies[0] = proxy1;
+        proxies[1] = proxy2;
+
+        factory.batchFlushTokens(proxies, address(token));
+        assertEq(token.balanceOf(vault), 125e6);
+        assertEq(token.balanceOf(proxy1), 0);
+        assertEq(token.balanceOf(proxy2), 0);
+    }
+
+    function testOnlyFactoryCanFlush() public {
+        bytes32 salt = keccak256("order-5");
+        address proxy = factory.deploy(salt);
+
+        address[] memory recipients = new address[](1);
+        recipients[0] = buyer;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1e6;
+
+        vm.prank(address(0xdead));
+        vm.expectRevert(DepositForwarder_OnlyFactory.selector);
+        DepositForwarder(payable(proxy)).flushTokens(address(token), recipients, amounts);
+    }
+
+    function testOnlyOwnerCanDeploy() public {
+        bytes32 salt = keccak256("order-6");
+        vm.prank(address(0xdead));
+        vm.expectRevert();
+        factory.deploy(salt);
+    }
+
+    function testFlushNative() public {
+        bytes32 salt = keccak256("order-native");
+        address proxy = factory.deploy(salt);
+        vm.deal(proxy, 1 ether);
+
+        factory.flushNative(payable(proxy), payable(vault));
+        assertEq(vault.balance, 1 ether);
+        assertEq(proxy.balance, 0);
+    }
+
+    function testFlushNativeOnlyFactory() public {
+        bytes32 salt = keccak256("order-native-guard");
+        address proxy = factory.deploy(salt);
+        vm.deal(proxy, 1 ether);
+
+        vm.prank(address(0xdead));
+        vm.expectRevert(DepositForwarder_OnlyFactory.selector);
+        DepositForwarder(payable(proxy)).flushNative(payable(vault));
+    }
+
+    function testFlushNativeViaFactory() public {
+        bytes32 salt = keccak256("order-native-factory");
+        address proxy = factory.deploy(salt);
+        vm.deal(proxy, 2 ether);
+
+        factory.flushNative(payable(proxy), payable(vault));
+        assertEq(vault.balance, 2 ether);
+        assertEq(proxy.balance, 0);
+    }
+
+    function testFlushNativeOnlyOwner() public {
+        bytes32 salt = keccak256("order-native-owner");
+        address proxy = factory.deploy(salt);
+        vm.deal(proxy, 1 ether);
+
+        vm.prank(address(0xdead));
+        vm.expectRevert();
+        factory.flushNative(payable(proxy), payable(vault));
+    }
+
+    function testZeroAddressImplementationReverts() public {
+        vm.expectRevert(ForwarderFactory_InvalidAddress.selector);
+        new ForwarderFactory(address(0), vault);
+    }
+
+    function testZeroAddressVaultReverts() public {
+        vm.expectRevert(ForwarderFactory_InvalidAddress.selector);
+        new ForwarderFactory(address(impl), address(0));
+    }
+
+    function testInitZeroAddressReverts() public {
+        DepositForwarder raw = new DepositForwarder();
+        vm.expectRevert(DepositForwarder_InvalidFactory.selector);
+        raw.init(address(0));
+    }
+
+    function testCanReceiveTokensBeforeDeployment() public {
+        bytes32 salt = keccak256("pre-deploy");
+        address predicted = factory.computeAddress(salt);
+
+        token.mint(predicted, 200e6);
+        assertEq(token.balanceOf(predicted), 200e6);
+
+        address[] memory recipients = new address[](1);
+        recipients[0] = vault;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 200e6;
+
+        factory.deployAndFlush(salt, address(token), recipients, amounts);
+        assertEq(token.balanceOf(vault), 200e6);
+        assertEq(token.balanceOf(predicted), 0);
+    }
+
+    function testDoubleInitReverts() public {
+        bytes32 salt = keccak256("order-double-init");
+        address proxy = factory.deploy(salt);
+
+        vm.expectRevert(DepositForwarder_AlreadyInitialized.selector);
+        DepositForwarder(payable(proxy)).init(address(0xdead));
+    }
+}


### PR DESCRIPTION
## Summary
- Implements CREATE2 + ERC-1167 minimal proxy deposit address system replacing HD-derived EOA wallets
- **DepositForwarder**: proxy implementation with `flushTokens()` (ERC-20 multi-recipient) and `flushNative()` (POL recovery), restricted by `onlyFactory` modifier
- **ForwarderFactory**: deterministic proxy deployment via OpenZeppelin Clones, with `computeAddress()`, `deployAndFlush()` (atomic single-tx settlement), and `batchFlushTokens()` (sweep multiple proxies to vault)
- Zero-address validation on all critical parameters (constructor, init)
- Implementation locked at deployment to prevent unauthorized initialization

## Changes
- `src/DepositForwarder.sol` -- Proxy implementation contract (58 lines)
- `src/ForwarderFactory.sol` -- Factory/orchestrator contract (58 lines)
- `script/DeployForwarder.s.sol` -- Foundry deployment script
- `test/unit/Forwarder.t.sol` -- 16 Foundry tests (203 lines)
- `test/mocks/ERC20Mock.sol` -- ERC-20 mock for testing

## Test Plan
- [x] 16/16 Foundry tests passing
- [x] Deterministic address computation verified
- [x] Deploy + flush atomic operation verified
- [x] Batch sweep verified
- [x] Access control (onlyFactory, onlyOwner) verified
- [x] Zero-address validation verified
- [x] Double-init prevention verified
- [x] Native POL recovery verified
- [ ] Deploy to Polygon Amoy (dev) and test end-to-end
- [ ] Deploy to Polygon mainnet (prod)